### PR TITLE
Remove licence verification gate from app layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,15 +1,5 @@
 @php
 $hasActiveLicense = true;
-if(isLoggedIn() and (request()->route()->getName() != 'manage.configuration.product_registration') and
-(!getAppSettings('product_registration', 'registration_id') or sha1(array_get($_SERVER, 'HTTP_HOST', '') .
-getAppSettings('product_registration', 'registration_id') . '4.5+') !== getAppSettings('product_registration',
-'signature'))) {
-$hasActiveLicense = false;
-if(hasCentralAccess()) {
-header("Location: " . route('manage.configuration.product_registration'));
-exit;
-}
-}
 $currentAppTheme ='';
  // Default theme from settings
  $currentAppTheme = getUserAppTheme()


### PR DESCRIPTION
## Summary
- remove the product registration check and redirect logic from the main layout so the app always treats the licence as active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8f67f469483288adeee76f38c8fff