### PR TITLE
Add privacy policy route and update references

### DIFF
--- a/app/Yantrana/Components/Home/Controllers/HomeController.php
+++ b/app/Yantrana/Components/Home/Controllers/HomeController.php
@@ -150,6 +150,11 @@ class HomeController extends BaseController
         ]);
     }
 
+    public function privacyPolicy()
+    {
+        return $this->viewTermsAndPolicies('privacy_policy');
+    }
+
     public function generateWhatsAppQR($vendorUid = null, $phoneNumber = null)
     {
         if(!$vendorUid or !$phoneNumber) {

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -135,9 +135,7 @@
                                             ]) }}">{{ __tr('Vendor Terms And Conditions') }}</a>,
                                             @endif
                                             @if (getAppSettings('privacy_policy'))
-                                            <a class="text-success" href="{{ route('app.terms_and_policies', [
-                                                'contentName' => 'privacy_policy'
-                                            ]) }}">{{
+                                            <a class="text-success" href="{{ route('app.privacy_policy') }}">{{
                                                 __tr('Privacy Policy')
                                                 }}</a>
                                             @endif

--- a/resources/views/configuration/user.blade.php
+++ b/resources/views/configuration/user.blade.php
@@ -89,11 +89,7 @@
 			<textarea rows="10" name="privacy_policy" class="form-control form-control-user" id="lwPrivacy PolicyTerms"><?= getAppSettings('privacy_policy') ?></textarea>
             <small class="form-text text-muted">{{  __tr('It will be your Privacy Policy') }}</small>
             <div class="my-3 text-muted">
-                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.terms_and_policies', [
-                    'contentName' => 'privacy_policy'
-                ]) }}">{{ route('app.terms_and_policies', [
-                    'contentName' => 'privacy_policy'
-                ]) }}</a></small>
+                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.privacy_policy') }}">{{ route('app.privacy_policy') }}</a></small>
             </div>
 		</div>
 		<!-- / Privacy Policy Terms -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Redirect;
+use App\Yantrana\Components\Home\Controllers\HomeController;
 use App\Yantrana\Components\Page\Controllers\PageController;
 use App\Yantrana\Components\User\Controllers\UserController;
 use App\Yantrana\Components\Media\Controllers\MediaController;
@@ -1333,6 +1334,10 @@ Route::get('/terms-and-policies/{contentName?}', [
     HomeController::class,
     'viewTermsAndPolicies',
 ])->name('app.terms_and_policies');
+Route::get('/privacy-policy', [
+    HomeController::class,
+    'privacyPolicy',
+])->name('app.privacy_policy');
 // whatsapp qr code
 Route::get('/whatsapp-qr/{vendorUid}/{phoneNumber}', [
     HomeController::class,


### PR DESCRIPTION
## Summary
- add a privacyPolicy controller action that reuses the existing terms rendering helper
- register a /privacy-policy route named app.privacy_policy
- update privacy policy links in the registration and configuration views to use the new route

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2bb94eac8328a0758a5a0987380b