### PR TITLE
Add guest privacy policy page with fallback copy

### DIFF
--- a/resources/views/configuration/user.blade.php
+++ b/resources/views/configuration/user.blade.php
@@ -89,11 +89,10 @@
 			<textarea rows="10" name="privacy_policy" class="form-control form-control-user" id="lwPrivacy PolicyTerms"><?= getAppSettings('privacy_policy') ?></textarea>
             <small class="form-text text-muted">{{  __tr('It will be your Privacy Policy') }}</small>
             <div class="my-3 text-muted">
-                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.terms_and_policies', [
-                    'contentName' => 'privacy_policy'
-                ]) }}">{{ route('app.terms_and_policies', [
-                    'contentName' => 'privacy_policy'
-                ]) }}</a></small>
+                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.privacy_policy') }}">{{ route('app.privacy_policy') }}</a></small>
+                <div class="mt-2">
+                    <small>{{ __tr('If you leave this field blank, visitors will see the default privacy policy template.') }}</small>
+                </div>
             </div>
 		</div>
 		<!-- / Privacy Policy Terms -->

--- a/resources/views/privacy-policy.blade.php
+++ b/resources/views/privacy-policy.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app', ['class' => 'main-content-has-bg'])
+
+@section('content')
+@include('layouts.headers.guest')
+@php
+    $policyHtml = trim((string) getAppSettings('privacy_policy'));
+@endphp
+<div class="container lw-guest-page-container-block pb-2">
+    <div class="row justify-content-center">
+        <div class="col-lg-12 col-md-8">
+            <div class="card shadow border-0">
+                <h1 class="card-header text-center">
+                    {{ __tr('Privacy Policy') }}
+                </h1>
+                <div class="card-body px-lg-5 py-lg-5 p lw-ws-pre-line">
+                    @if($policyHtml !== '')
+                        {!! $policyHtml !!}
+                    @else
+                        <p>{{ __tr(':appName is committed to protecting your privacy. This page explains what information we collect, how we use it, and the choices you have about your personal data.', ['appName' => config('app.name')]) }}</p>
+                        <p>{{ __tr('We only collect the information that is necessary to deliver and improve our services. This may include contact details, account credentials, and usage data that helps us keep the platform secure and reliable.') }}</p>
+                        <p>{{ __tr('Any information you share with us is handled responsibly. We never sell your personal data, and we only share it with trusted partners when it is essential to operate or comply with the law.') }}</p>
+                        <p>{{ __tr('If you have questions about this policy or would like to exercise your privacy rights, please contact us through the support options provided in the application.') }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Redirect;
 use App\Yantrana\Components\Page\Controllers\PageController;
+use App\Yantrana\Components\Home\Controllers\HomeController;
 use App\Yantrana\Components\User\Controllers\UserController;
 use App\Yantrana\Components\Media\Controllers\MediaController;
 use App\Yantrana\Components\Vendor\Controllers\VendorController;
@@ -1333,6 +1334,7 @@ Route::get('/terms-and-policies/{contentName?}', [
     HomeController::class,
     'viewTermsAndPolicies',
 ])->name('app.terms_and_policies');
+Route::view('/privacy-policy', 'privacy-policy')->name('app.privacy_policy');
 // whatsapp qr code
 Route::get('/whatsapp-qr/{vendorUid}/{phoneNumber}', [
     HomeController::class,


### PR DESCRIPTION
## Summary
- add a dedicated guest privacy policy blade view that renders saved HTML or a default fallback copy
- register a friendly `/privacy-policy` route and ensure HomeController is imported for related routes
- update the admin privacy policy configuration link to point to the new route and explain the fallback behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2bb484c883288a6d9e9df36a2d4f