### PR TITLE
Add privacy policy route and update links

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -135,9 +135,7 @@
                                             ]) }}">{{ __tr('Vendor Terms And Conditions') }}</a>,
                                             @endif
                                             @if (getAppSettings('privacy_policy'))
-                                            <a class="text-success" href="{{ route('app.terms_and_policies', [
-                                                'contentName' => 'privacy_policy'
-                                            ]) }}">{{
+                                            <a class="text-success" href="{{ route('app.privacy_policy') }}">{{
                                                 __tr('Privacy Policy')
                                                 }}</a>
                                             @endif

--- a/resources/views/configuration/user.blade.php
+++ b/resources/views/configuration/user.blade.php
@@ -89,11 +89,7 @@
 			<textarea rows="10" name="privacy_policy" class="form-control form-control-user" id="lwPrivacy PolicyTerms"><?= getAppSettings('privacy_policy') ?></textarea>
             <small class="form-text text-muted">{{  __tr('It will be your Privacy Policy') }}</small>
             <div class="my-3 text-muted">
-                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.terms_and_policies', [
-                    'contentName' => 'privacy_policy'
-                ]) }}">{{ route('app.terms_and_policies', [
-                    'contentName' => 'privacy_policy'
-                ]) }}</a></small>
+                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.privacy_policy') }}">{{ route('app.privacy_policy') }}</a></small>
             </div>
 		</div>
 		<!-- / Privacy Policy Terms -->

--- a/resources/views/outer-home-2.blade.php
+++ b/resources/views/outer-home-2.blade.php
@@ -757,7 +757,7 @@ $appName = getAppSettings('name');
                                     <li><a href="#"> {{ __tr('About') }}</a></li>
                                     <li><a href="#"> {{ __tr('Careers') }}</a></li>
                                     <li><a href="#"> {{ __tr('Our Services') }}</a></li>
-                                    <li><a href="#"> {{ __tr('Privacy policy') }}</a></li>
+                                    <li><a href="{{ route('app.privacy_policy') }}"> {{ __tr('Privacy policy') }}</a></li>
                                     <li><a href="#"> {{ __tr('terms and conditions') }}</a></li>
                                 </ul>
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Yantrana\Components\User\Controllers\UserController;
 use App\Yantrana\Components\Media\Controllers\MediaController;
 use App\Yantrana\Components\Vendor\Controllers\VendorController;
 use App\Yantrana\Components\Contact\Controllers\ContactController;
+use App\Yantrana\Components\Home\Controllers\HomeController;
 use App\Yantrana\Components\BotReply\Controllers\BotFlowController;
 use App\Yantrana\Components\BotReply\Controllers\BotReplyController;
 use App\Yantrana\Components\Campaign\Controllers\CampaignController;
@@ -1333,6 +1334,10 @@ Route::get('/terms-and-policies/{contentName?}', [
     HomeController::class,
     'viewTermsAndPolicies',
 ])->name('app.terms_and_policies');
+
+Route::get('/privacy-policy', function () {
+    return app(HomeController::class)->viewTermsAndPolicies('privacy_policy');
+})->name('app.privacy_policy');
 // whatsapp qr code
 Route::get('/whatsapp-qr/{vendorUid}/{phoneNumber}', [
     HomeController::class,


### PR DESCRIPTION
## Summary
- register a dedicated /privacy-policy endpoint that reuses the existing HomeController terms view
- update registration, configuration, and marketing footer templates to point to the new privacy policy URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2baa2d848328aa4fc676d5a36532