### PR TITLE
Update footer policy links to real routes

### DIFF
--- a/resources/views/outer-home-2.blade.php
+++ b/resources/views/outer-home-2.blade.php
@@ -757,8 +757,8 @@ $appName = getAppSettings('name');
                                     <li><a href="#"> {{ __tr('About') }}</a></li>
                                     <li><a href="#"> {{ __tr('Careers') }}</a></li>
                                     <li><a href="#"> {{ __tr('Our Services') }}</a></li>
-                                    <li><a href="#"> {{ __tr('Privacy policy') }}</a></li>
-                                    <li><a href="#"> {{ __tr('terms and conditions') }}</a></li>
+                                    <li><a href="{{ route('app.terms_and_policies', ['contentName' => 'privacy_policy']) }}"> {{ __tr('Privacy policy') }}</a></li>
+                                    <li><a href="{{ route('app.terms_and_policies', ['contentName' => 'user_terms']) }}"> {{ __tr('terms and conditions') }}</a></li>
                                 </ul>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- replace the footer privacy and terms placeholders with calls to the existing terms and policies routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2ba7239483289237ee8527521bcb