### PR TITLE
Add dedicated privacy policy route and smoke test

### DIFF
--- a/app/Yantrana/Components/Home/Controllers/HomeController.php
+++ b/app/Yantrana/Components/Home/Controllers/HomeController.php
@@ -150,6 +150,11 @@ class HomeController extends BaseController
         ]);
     }
 
+    public function privacyPolicy()
+    {
+        return $this->viewTermsAndPolicies('privacy_policy');
+    }
+
     public function generateWhatsAppQR($vendorUid = null, $phoneNumber = null)
     {
         if(!$vendorUid or !$phoneNumber) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Redirect;
+use App\Yantrana\Components\Home\Controllers\HomeController;
 use App\Yantrana\Components\Page\Controllers\PageController;
 use App\Yantrana\Components\User\Controllers\UserController;
 use App\Yantrana\Components\Media\Controllers\MediaController;
@@ -1333,6 +1334,11 @@ Route::get('/terms-and-policies/{contentName?}', [
     HomeController::class,
     'viewTermsAndPolicies',
 ])->name('app.terms_and_policies');
+
+Route::get('/privacy-policy', [
+    HomeController::class,
+    'privacyPolicy',
+])->name('privacy.policy');
 // whatsapp qr code
 Route::get('/whatsapp-qr/{vendorUid}/{phoneNumber}', [
     HomeController::class,

--- a/tests/Feature/PrivacyPolicyTest.php
+++ b/tests/Feature/PrivacyPolicyTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PrivacyPolicyTest extends TestCase
+{
+    /**
+     * Ensure the privacy policy page is accessible without parameters.
+     */
+    public function test_privacy_policy_page_is_accessible(): void
+    {
+        config()->set('__settings.autoload_exceptions', []);
+        config(['__flash_cached__.app_setting_all' => []]);
+
+        $response = $this->get('/privacy-policy');
+
+        $response->assertOk();
+        $response->assertSee('Privacy Policy');
+    }
+}


### PR DESCRIPTION
## Summary
- add a HomeController action that renders the privacy policy without requiring a route parameter
- register a named /privacy-policy route that points to the new controller method
- add a smoke test that ensures the privacy policy page responds successfully and includes its heading

## Testing
- ⚠️ `php artisan test --filter=PrivacyPolicyTest` *(fails: composer install requires GitHub access token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2ba463088328afcc87e0d99f4b6c