### PR TITLE
Ensure privacy policy page is accessible

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -135,7 +135,7 @@
                                             ]) }}">{{ __tr('Vendor Terms And Conditions') }}</a>,
                                             @endif
                                             @if (getAppSettings('privacy_policy'))
-                                            <a class="text-success" href="{{ route('app.privacy_policy') }}">{{
+                                            <a class="text-success" href="{{ route('privacy.policy') }}">{{
                                                 __tr('Privacy Policy')
                                                 }}</a>
                                             @endif

--- a/resources/views/configuration/user.blade.php
+++ b/resources/views/configuration/user.blade.php
@@ -90,7 +90,7 @@
             <small class="form-text text-muted d-block">{{  __tr('It will be your Privacy Policy') }}</small>
             <small class="form-text text-muted">{{  __tr("A default template is provided below—feel free to customise this text to reflect your organisation's practices.") }}</small>
             <div class="my-3 text-muted">
-                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('app.privacy_policy') }}">{{ route('app.privacy_policy') }}</a></small>
+                <small>{{ __tr('Public link : ') }} <a target="_blank" href="{{ route('privacy.policy') }}">{{ route('privacy.policy') }}</a></small>
             </div>
 		</div>
 		<!-- / Privacy Policy Terms -->

--- a/resources/views/outer-home-2.blade.php
+++ b/resources/views/outer-home-2.blade.php
@@ -757,7 +757,7 @@ $appName = getAppSettings('name');
                                     <li><a href="#"> {{ __tr('About') }}</a></li>
                                     <li><a href="#"> {{ __tr('Careers') }}</a></li>
                                     <li><a href="#"> {{ __tr('Our Services') }}</a></li>
-                                    <li><a href="{{ route('app.terms_and_policies', ['contentName' => 'privacy_policy']) }}"> {{ __tr('Privacy policy') }}</a></li>
+                                    <li><a href="{{ route('privacy.policy') }}"> {{ __tr('Privacy policy') }}</a></li>
                                     <li><a href="{{ route('app.terms_and_policies', ['contentName' => 'user_terms']) }}"> {{ __tr('terms and conditions') }}</a></li>
                    </ul>
                             </div>

--- a/resources/views/terms-policies.blade.php
+++ b/resources/views/terms-policies.blade.php
@@ -6,7 +6,7 @@
         <div class="col-lg-12 col-md-8">
             <div class="card shadow border-0">
                 <h1 class="card-header text-center">
-                    {{  str_replace('_',' ', Str::title($validItems[$contentName])) }}
+                    {{  str_replace('_',' ', \Illuminate\Support\Str::title($validItems[$contentName])) }}
                 </h1>
                 @php
                     $rawContent = getAppSettings($contentName);


### PR DESCRIPTION
## Summary
- qualify the privacy policy heading helper to avoid runtime errors when loading the compliance page
- update registration, configuration, and marketing footer links to use the dedicated `/privacy-policy` route

## Testing
- not run (vendor directory is not installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc2aaa56a88328931b6cd3c661471d