### PR TITLE
Add nginx reverse proxy configuration for whatsapp API domain

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+APP_URL=https://whatsappapi.eduskillbridge.net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,18 @@ services:
             - mysql
             - redis
             # - selenium
+    nginx:
+        image: 'nginx:alpine'
+        ports:
+            - '80:80'
+            - '443:443'
+        volumes:
+            - './docker/nginx/whatsappapi.conf:/etc/nginx/conf.d/whatsappapi.conf:ro'
+            - '/etc/letsencrypt:/etc/letsencrypt:ro'
+        depends_on:
+            - laravel.test
+        networks:
+            - sail
     # selenium:
     #     image: 'selenium/standalone-chrome'
     #     volumes:

--- a/docker/nginx/whatsappapi.conf
+++ b/docker/nginx/whatsappapi.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name whatsappapi.eduskillbridge.net;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name whatsappapi.eduskillbridge.net;
+
+    ssl_certificate /etc/letsencrypt/live/whatsappapi.eduskillbridge.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/whatsappapi.eduskillbridge.net/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256';
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header X-XSS-Protection "1; mode=block";
+
+    location / {
+        proxy_pass http://laravel.test:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add an nginx reverse proxy service to the Sail docker-compose stack exposing ports 80 and 443
- provide an nginx configuration that terminates TLS for whatsappapi.eduskillbridge.net and forwards requests to the Laravel container
- set the application APP_URL to the https endpoint for consistent link generation

## Testing
- not run (Docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de4004015483289b6e99f4812720e4