### PR TITLE
Add nginx reverse proxy configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,18 @@ services:
             - 'sailredis:/data'
         networks:
             - sail
+    reverse-proxy:
+        image: 'nginx:alpine'
+        ports:
+            - '80:80'
+            - '443:443'
+        volumes:
+            - './infrastructure/nginx:/etc/nginx/conf.d:ro'
+            - '/etc/letsencrypt:/etc/letsencrypt:ro'
+        depends_on:
+            - laravel.test
+        networks:
+            - sail
     # memcached:
     #     image: 'memcached:alpine'
     #     ports:

--- a/infrastructure/nginx/whatsappapi.conf
+++ b/infrastructure/nginx/whatsappapi.conf
@@ -1,0 +1,30 @@
+upstream laravel_app {
+    server laravel.test:80;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name whatsappapi.eduskillbridge.net;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name whatsappapi.eduskillbridge.net;
+
+    ssl_certificate /etc/letsencrypt/live/whatsappapi.eduskillbridge.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/whatsappapi.eduskillbridge.net/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass http://laravel_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add an nginx reverse proxy service to docker-compose so traffic on ports 80/443 is forwarded to the Laravel Sail container
- provide an nginx server block for whatsappapi.eduskillbridge.net referencing the existing Let's Encrypt certificates
- mount the nginx configuration directory and Let's Encrypt certificate directory into the proxy container

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de40f566548328b04f5f6718ae72d3